### PR TITLE
Add support for Samsung devices

### DIFF
--- a/app/src/main/java/be/mygod/pogoplusplus/BluetoothPairingService.kt
+++ b/app/src/main/java/be/mygod/pogoplusplus/BluetoothPairingService.kt
@@ -38,10 +38,9 @@ class BluetoothPairingService : AccessibilityService() {
                 if (confirm.size != 1) return
                 val title = root.findAccessibilityNodeInfosByViewId("$PACKAGE_SETTINGS:id/alertTitle")
                 val message = root.findAccessibilityNodeInfosByViewId("$PACKAGE_SETTINGS:id/message")
-                if (!(title.size == 1 && title[0].text.contains(BluetoothReceiver.DEVICE_NAME_PGP)) &&
-                    !(message.size == 1 && message[0].text.contains(BluetoothReceiver.DEVICE_NAME_PGP))) {
-                    return
-                }
+                val titleHasDevice = title.size == 1 && title[0].text.contains(BluetoothReceiver.DEVICE_NAME_PGP)
+                val messageHasDevice = message.size == 1 && message[0].text.contains(BluetoothReceiver.DEVICE_NAME_PGP)
+                if (!titleHasDevice && !messageHasDevice) return
                 confirm[0].performAction(AccessibilityNodeInfo.ACTION_CLICK)
             }
             else -> Timber.e(Exception("Unknown event ${event.eventType}"))

--- a/app/src/main/java/be/mygod/pogoplusplus/BluetoothPairingService.kt
+++ b/app/src/main/java/be/mygod/pogoplusplus/BluetoothPairingService.kt
@@ -34,12 +34,14 @@ class BluetoothPairingService : AccessibilityService() {
             }
             AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> {
                 val root = rootInActiveWindow ?: return
-                if (root.findAccessibilityNodeInfosByViewId(
-                        "$PACKAGE_SETTINGS:id/phonebook_sharing_message_confirm_pin").size != 1) return
                 val confirm = root.findAccessibilityNodeInfosByViewId("android:id/button1")
                 if (confirm.size != 1) return
                 val title = root.findAccessibilityNodeInfosByViewId("$PACKAGE_SETTINGS:id/alertTitle")
-                if (title.size != 1 || !title[0].text.contains(BluetoothReceiver.DEVICE_NAME_PGP)) return
+                val message = root.findAccessibilityNodeInfosByViewId("$PACKAGE_SETTINGS:id/message")
+                if (!(title.size == 1 && title[0].text.contains(BluetoothReceiver.DEVICE_NAME_PGP)) &&
+                    !(message.size == 1 && message[0].text.contains(BluetoothReceiver.DEVICE_NAME_PGP))) {
+                    return
+                }
                 confirm[0].performAction(AccessibilityNodeInfo.ACTION_CLICK)
             }
             else -> Timber.e(Exception("Unknown event ${event.eventType}"))


### PR DESCRIPTION
Remove check for phonebook_sharing_message_confirm_pin as that isn't used on all devices.

Added option of checking the message view in addition to the title to see if the device is a go plus.

Changed logic to handle cases where either the title or message aren't used. OnePlus doesn't use message at all.